### PR TITLE
Add codebuild role name as output

### DIFF
--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -12,3 +12,7 @@ output "codebuild_security_group_id" {
   value       = "${module.codebuild_sqitch_shared_resources.codebuild_security_group_id}"
   description = "The ID for codebuild-sqitch security group. Use this when creating sqitch codebuild pipelines"
 }
+
+output "codebuild_role_name" {
+  value       = "${module.codebuild_sqitch_shared_resources.codebuild_role_name}"
+  description = "The sqitch codebuild role's Name"}

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,6 @@ output "codebuild_security_group_id" {
 }
 
 output "codebuild_role_name" {
-  value = "${module.codebuild_role.role_name}"
+  value       = "${module.codebuild_role.role_name}"
   description = "The sqitch codebuild role's Name. Useful for attaching additional policies through aws_iam_role_policy_attachment"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "codebuild_security_group_id" {
   value       = "${aws_security_group.codebuild_sqitch.id}"
   description = "The ID for codebuild-sqitch security group. Use this when creating sqitch codebuild pipelines"
 }
+
+output "codebuild_role_name" {
+  value = "${module.codebuild_role.role_name}"
+  description = "The sqitch codebuild role's Name. Useful for attaching additional policies through aws_iam_role_policy_attachment"
+}


### PR DESCRIPTION
Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-modules-template/blob/master/CHANGELOG.md):
```release-note
ENHANCEMENTS:

- Expose role name as output so that caller modules can attach additional policies.

